### PR TITLE
Add valid gemspec

### DIFF
--- a/syslog_ruby.gemspec
+++ b/syslog_ruby.gemspec
@@ -4,8 +4,8 @@ require File.expand_path('../lib/syslog_ruby/version', __FILE__)
 Gem::Specification.new do |gem|
   gem.authors       = ["John Skopis"]
   gem.email         = ["john.skopis@causes.com"]
-  gem.description   = %q{TODO: Write a gem description}
-  gem.summary       = %q{TODO: Write a gem summary}
+  gem.description   = %q{Ruby Logger that sends directly to a variety of syslog endpoints}
+  gem.summary       = %q{Ruby Logger that sends directly to a variety of syslog endpoints}
   gem.homepage      = ""
 
   gem.files         = `git ls-files`.split($\)


### PR DESCRIPTION
Hi. I really wanted to use your code to post syslog messages over TCP. Rather than take & own a copy of your code, which works for me as-is, I've forked and modified the gemspec file.
This was the only change I needed to make in order to turn it into a valid gem.
So I've pushed the gem to rubygems.org also: https://rubygems.org/gems/syslog_ruby 
